### PR TITLE
Elo score calculation when multiple players forfeit

### DIFF
--- a/bob.js
+++ b/bob.js
@@ -513,7 +513,7 @@ chooseLbpMeLevel = (level, message) => {
         result.on("end", function () {
             start = dataQueue.search("<title>") + 7;
             end = dataQueue.search(" - LBP.me</title>");
-            titleAuthor = dataQueue.substring(start, end).trim();
+            titleAuthor = decodeHTML(dataQueue.substring(start, end).trim());
             split = titleAuthor.split(" ");
             title = titleAuthor.substring(0, titleAuthor.search(split[split.length - 1])).trim();
             levelName = title + (isVita ? " - https://vita.lbp.me/v/" : " - https://lbp.me/v/") + level.split("/")[4]; 
@@ -1153,5 +1153,31 @@ arrayRemove = (arr, value) => {
 isILRace = () => {
     return categoryName === "Individual Levels";
 }
+
+// The following code is based on https://github.com/intesso/decode-html to avoid additional dependencies ---------
+// Store markers outside of the function scope,
+// not to recreate them on every call
+const entities = {
+  'amp': '&',
+  'apos': '\'',
+  'lt': '<',
+  'gt': '>',
+  'quot': '"',
+  'nbsp': ' '
+};
+const entityPattern = RegExp("&([a-z]+);", "ig");
+
+decodeHTML = (text) => {
+  // A single replace pass with a static RegExp is faster than a loop
+  return text.replace(entityPattern, function(match, entity) {
+    entity = entity.toLowerCase();
+    if (entities.hasOwnProperty(entity)) {
+      return entities[entity];
+    }
+    // return original string if there is no matching entity (no replace)
+    return match;
+  });
+};
+// ----------------------------------------------------------------------------------------------------------------
 
 client.login(config.token);

--- a/bob.js
+++ b/bob.js
@@ -1056,11 +1056,13 @@ recordResults = () => {
             if (id1 === id2) {
                 return;
             }
+
+            expectedScore += 1.0 / (1 + Math.pow(10, (playerStats.get(id2).elo - playerStats.get(id1).elo) / 400));
             
             if (raceState.ffEntrants.includes(id1)) {
                 if (raceState.ffEntrants.includes(id2)) {
-                    // If both players forfeited, count them as tied
-                    actualScore += 0.5;
+                    // If both players forfeited, those two players won't affect each other's scores
+                    actualScore += expectedScore;
                 } else {
                     // Loss gives 0 points
                 }
@@ -1070,7 +1072,6 @@ recordResults = () => {
             } else {
                 // Loss gives 0 points
             }
-            expectedScore += 1.0 / (1 + Math.pow(10, (playerStats.get(id2).elo - playerStats.get(id1).elo) / 400));
         });
 
         newElos.set(id1, playerStats.get(id1).elo + 32 * (actualScore - expectedScore));

--- a/elo_fix.js
+++ b/elo_fix.js
@@ -102,11 +102,13 @@ fixElosCmd = (message) => {
                     if (fixObj1 === fixObj2) {
                         return;
                     }
+
+                    expectedScore += 1.0 / (1 + Math.pow(10, (playerStats.get(fixObj2.userId).elo - playerStats.get(fixObj1.userId).elo) / 400));
                     
                     if (ffs.includes(fixObj1)) {
                         if (ffs.includes(fixObj2)) {
-                            // If both players forfeited, count them as tied
-                            actualScore += 0.5;
+                            // If both players forfeited, those two players won't affect each other's scores
+                            actualScore += expectedScore;
                         } else {
                             // Loss gives 0 points
                         }
@@ -116,7 +118,6 @@ fixElosCmd = (message) => {
                     } else {
                         // Loss gives 0 points
                     }
-                    expectedScore += 1.0 / (1 + Math.pow(10, (playerStats.get(fixObj2.userId).elo - playerStats.get(fixObj1.userId).elo) / 400));
                 });
 
                 newElos.set(fixObj1.userId, playerStats.get(fixObj1.userId).elo + 32 * (actualScore - expectedScore));


### PR DESCRIPTION
If you compare two players to calculate the Elo score and both players forfeited, they shouldn't get 0.5 score points each, but instead get their respective expected scores as their actual scores, because then their total Elo scores aren't affected by comparing those two players.

Before this change bad players who forfeited automatically earned Elo points if better players also forfeited.