### PR TITLE
Roles rewrite progress

### DIFF
--- a/bob.js
+++ b/bob.js
@@ -204,7 +204,10 @@ client.on("message", (message) => {
 
         // Admin/Mod only commands
         else if (message.member.roles.cache.some(role => role.name === "Admin" || role.name === "Moderator")) {
-            if (lowerMessage.startsWith("!kick"))
+            if (lowerMessage.startsWith("!modhelp"))
+                modHelpCmd(message);
+
+            else if (lowerMessage.startsWith("!kick"))
                 kickCmd(message);
 
             else if (lowerMessage.startsWith("!clearrace"))
@@ -269,23 +272,19 @@ helpCmd = (message) => {
 \`!elo <game name>/<category name>\` - Shows the ELO leaderboard for the given game/category (e.g. \`!elo lbp/die%\` shows the LBP1 Die% leaderboard).
 \`!help\` - Shows this message.
 
-**Fun command**
+**Other commands**
+\`!roles <speedrun.com name>\` - Updates your roles. If you have a run on an LBP leaderboard and linked your discord account on speedrun.com, you will receive the corresponding runner roles. You can also get roles from finishing races.
 \`!nr\` / \`!newrunner\` - Mixes two halves of the names of random LBP runners (that have a full-game run on sr.c) together.
 `);
+}
 
+modHelpCmd = (message) => {
     message.channel.send(`
 **Admin/moderator only (mid-race)**
 \`!kick @user\` - Kicks someone from the race (in case they're afk or something).
 \`!clearrace\` - Resets the bot; forces ending the race without recording any results.
-
-**speedrun.com role commands**
-*Using the keyword \`all\` requires admin/mod rights.*
-\`!roles autoconnect <sr.c name>\` / \`all\` - Reloads the user's discord data / all auto connected discord accounts entered on sr.c.
-\`!roles connect <sr.c name>\` - Manually connects an sr.c profile to you.
-\`!roles disconnect <sr.c name>\` - Disconnects an sr.c profile.
-\`!roles reload leaderboard <game name>\` / \`all\` - Reloads the runs on the specified sr.c leaderboards / all leaderboards.
-\`!roles reload categories\` - Reloads all categories.
-\`!roles reload all\` - Reloads everything. Don't use this unless it's necessary.
+\`!roles <speedrun.com name> <discord id>\` - Updates someone else's roles.
+\`!reloadroles\` - Refreshes all registered roles.
 `);
 }
 
@@ -1043,6 +1042,7 @@ recordResults = () => {
         entrant = raceState.entrants.get(id);
         result = { race_id: `${raceId}`, user_id: `${id}`, user_name: `${username(entrant.message)}`, game: `${gameName}`, category: `${categoryName}`, time: `${entrant.doneTime}`, ff: 0, dq: 0 };
         client.addResult.run(result);
+        roles.giveRoleFromRace(id, gameName);
     });
     raceState.ffEntrants.forEach((id) => {
         entrant = raceState.entrants.get(id);


### PR DESCRIPTION
I think the first pass of the roles stuff was a decent experiment, but the complexity sort of out-stripped the gain of making it a bot feature in the first place. I think it was an attempt to automate too much while still requiring a lot of mod intervention, at which point it felt like it was easier to just manually apply the roles on discord without the bot.

So, I'm reworking the role stuff to put more of the responsibility on the runners rather than just the moderators. If someone wants roles, they will just need to run `!roles <srcom name>`. If their srcom profile is linked to their discord account, and they have run any LBP games, they will receive the correct roles. Also, people can get roles from doing races now.

Features that still need to be added:
* 24-hour auto role refresh
* Mod command to force refresh
* A command to let people unlink/remove roles
* Retroactively apply roles to people who have already done races?
* Check for matching linked accounts on discord/srcom (twitch, twitter, yt, etc.) so people don't need a linked discord account? (not currently possible with discord.js)